### PR TITLE
Issue 20 adapt to new evaluation workflow

### DIFF
--- a/ta2/search.py
+++ b/ta2/search.py
@@ -3,7 +3,6 @@ import itertools
 import json
 import logging
 import os
-import random
 import warnings
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -17,6 +16,7 @@ from d3m.metadata.problem import TaskType
 from d3m.runtime import evaluate
 
 from ta2.template import load_template
+from ta2.utils import dump_pipeline
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 PIPELINES_DIR = os.path.join(BASE_DIR, 'pipelines')
@@ -109,7 +109,11 @@ class PipelineSearcher:
         self.dump = dump
 
         self.ranked_dir = os.path.join(self.output, 'pipelines_ranked')
+        self.scored_dir = os.path.join(self.output, 'pipelines_scored')
+        self.searched_dir = os.path.join(self.output, 'pipelines_searched')
         os.makedirs(self.ranked_dir, exist_ok=True)
+        os.makedirs(self.scored_dir, exist_ok=True)
+        os.makedirs(self.searched_dir, exist_ok=True)
 
         self.datasets = self._find_datasets(input_dir)
         self.data_pipeline = self._load_pipeline('kfold_pipeline.yml')
@@ -141,29 +145,26 @@ class PipelineSearcher:
         pipeline.cv_scores = [score.value[0] for score in all_scores]
         pipeline.score = np.mean(pipeline.cv_scores)
 
-        return pipeline.score
+    def _save_pipeline(self, pipeline):
+        pipeline_dict = pipeline.to_json_structure()
 
-    def _save_pipeline(self, pipeline, normalized_score):
-        pipeline_json = pipeline.to_json_structure()
-        pipeline_json['score'] = pipeline.score
-        self.solutions.append(pipeline_json)
+        if pipeline.score is None:
+            dump_pipeline(pipeline_dict, self.searched_dir)
+        else:
+            dump_pipeline(pipeline_dict, self.scored_dir)
 
-        if self.dump:
-            rank = (1 - normalized_score) + random.random() * 1.e-12   # to avoid collisions
-            pipeline_json['pipeline_rank'] = rank
-            # pipeline_json['pipeline_rank'] = pipeline.rank
+            if self.dump:
+                dump_pipeline(pipeline_dict, self.ranked_dir, pipeline.normalized_score)
 
-            pipeline_filename = pipeline.id + '.json'
-            pipeline_path = os.path.join(self.ranked_dir, pipeline_filename)
-
-            with open(pipeline_path, 'w') as pipeline_file:
-                json.dump(pipeline_json, pipeline_file, indent=4)
+            pipeline_dict['score'] = pipeline.score
+            pipeline_dict['normalized_score'] = pipeline.normalized_score
+            self.solutions.append(pipeline_dict)
 
     @staticmethod
     def _new_pipeline(pipeline, hyperparams=None):
         hyperparams = to_dicts(hyperparams) if hyperparams else dict()
 
-        new_pipeline = Pipeline(context=Context.TESTING)
+        new_pipeline = Pipeline()
         for input_ in pipeline.inputs:
             new_pipeline.add_input(name=input_['name'])
 
@@ -260,26 +261,28 @@ class PipelineSearcher:
                 params = '\n'.join('{}: {}'.format(k, v) for k, v in proposal.items())
                 LOGGER.info("Scoring pipeline %s: %s\n%s", i + 1, pipeline.id, params)
                 try:
-                    score = self.score_pipeline(dataset, problem, pipeline)
-                    normalized_score = metric.normalize(score)
+                    self.score_pipeline(dataset, problem, pipeline)
+                    pipeline.normalized_score = metric.normalize(pipeline.score)
                 except Exception:
                     LOGGER.exception("Error scoring pipeline %s", pipeline.id)
-                    score = None
-                    normalized_score = 0.0
+                    pipeline.score = None
+                    pipeline.normalized_score = 0.0
 
                 try:
-                    self._save_pipeline(pipeline, normalized_score)
+                    self._save_pipeline(pipeline)
                 except Exception:
                     LOGGER.exception("Error saving pipeline %s", pipeline.id)
 
-                tuner.add(proposal, normalized_score)
-                LOGGER.info("Pipeline %s score: %s - %s", pipeline.id, score, normalized_score)
+                tuner.add(proposal, pipeline.normalized_score)
+                LOGGER.info("Pipeline %s score: %s - %s",
+                            pipeline.id, pipeline.score, pipeline.normalized_score)
 
-                if normalized_score > best_normalized:
-                    LOGGER.info("New best pipeline found! %s > %s", score, best_score)
+                if pipeline.normalized_score > best_normalized:
+                    LOGGER.info("New best pipeline found! %s is better than %s",
+                                pipeline.score, best_score)
                     best_pipeline = pipeline.id
-                    best_score = score
-                    best_normalized = normalized_score
+                    best_score = pipeline.score
+                    best_normalized = pipeline.normalized_score
 
                 proposal = tuner.propose(1)
 

--- a/ta2/ta3/core_servicer.py
+++ b/ta2/ta3/core_servicer.py
@@ -1293,6 +1293,7 @@ class CoreServicer(core_pb2_grpc.CoreServicer):
             pipeline = Pipeline.from_json_structure(solution)
             pipeline.cv_scores = list()
             pipeline.score = solution.get('score')
+            pipeline.normalized_score = solution.get('normalized_score')
             solution['session'] = session
 
             return pipeline, session

--- a/ta2/ta3/core_servicer.py
+++ b/ta2/ta3/core_servicer.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import random
 import tempfile
 import threading
 import time
@@ -21,6 +20,7 @@ from ta3ta2_api.problem_pb2 import PerformanceMetric, TaskSubtype, TaskType
 from ta3ta2_api.utils import decode_performance_metric, decode_problem_description, encode_score
 
 from ta2.search import PipelineSearcher
+from ta2.utils import dump_pipeline
 
 
 def recursivedict():
@@ -676,6 +676,7 @@ class CoreServicer(core_pb2_grpc.CoreServicer):
 
         self.input_dir = os.path.abspath(input_dir)
         self.output_dir = os.path.abspath(output_dir)
+        self.ranked_dir = os.path.join(self.output_dir, 'pipelines_ranked')
         self.timeout = timeout
         self.debug = debug
 
@@ -1162,8 +1163,7 @@ class CoreServicer(core_pb2_grpc.CoreServicer):
         for metric, pipeline in metric_pipelines:
             metric = decode_performance_metric(metric)
 
-            score = searcher.score_pipeline(dataset, problem, pipeline, [metric], **cv_args)
-            pipeline.score = score
+            searcher.score_pipeline(dataset, problem, pipeline, [metric], **cv_args)
 
     def ScoreSolution(self, request, context):
         """
@@ -1600,19 +1600,6 @@ class CoreServicer(core_pb2_grpc.CoreServicer):
 
         return self._stream(session, self._get_produce_solution_results, close_on_done=True)
 
-    def dump_pipeline(self, pipeline, rank):
-        if rank is None:
-            rank = (1 - pipeline.score) + random.random() * 1.e-12   # to avoid collisions
-
-        pipeline_json = pipeline.to_json_structure()
-        pipeline_json['pipeline_rank'] = rank
-
-        pipeline_filename = pipeline.id + '.json'
-        pipeline_path = os.path.join(self.output_dir, 'pipelines_ranked', pipeline_filename)
-
-        with open(pipeline_path, 'w') as pipeline_file:
-            json.dump(pipeline_json, pipeline_file, indent=4)
-
     def SolutionExport(self, request, context):
         """
         rpc SolutionExport (SolutionExportRequest) returns (SolutionExportResponse) {}
@@ -1636,7 +1623,8 @@ class CoreServicer(core_pb2_grpc.CoreServicer):
 
         runtime = self._get_fitted_solution(fitted_solution_id)
 
-        self.dump_pipeline(runtime.pipeline, rank)
+        pipeline = runtime.pipeline
+        dump_pipeline(pipeline, self.ranked_dir, pipeline.normalized_score, rank=rank)
 
         return core_pb2.SolutionExportResponse()
 

--- a/ta2/utils.py
+++ b/ta2/utils.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import io
+import json
 import os
+import random
 import tarfile
 import urllib
 
@@ -29,3 +31,22 @@ def ensure_downloaded(dataset_name):
     dataset_path = os.path.join(DATA_PATH, dataset_name)
     if not os.path.exists(dataset_path):
         _download(dataset_name)
+
+
+def dump_pipeline(pipeline, dump_dir, score=None, rank=None):
+    if not isinstance(pipeline, dict):
+        pipeline = pipeline.to_json_structure()
+
+    pipeline_filename = pipeline['id'] + '.json'
+    pipeline_path = os.path.join(dump_dir, pipeline_filename)
+    with open(pipeline_path, 'w') as pipeline_file:
+        json.dump(pipeline, pipeline_file, indent=4)
+
+    if score is not None and rank is None:
+        rank = (1 - score) + random.random() * 1.e-12   # avoid collisions
+
+    if rank is not None:
+        rank_filename = pipeline['id'] + '.rank'
+        rank_path = os.path.join(dump_dir, rank_filename)
+        with open(rank_path, 'w') as rank_file:
+            print(rank, file=rank_file)


### PR DESCRIPTION
Resolve #20 

Adapt to the new Evaluation Workflow requirements by:
* Storing successfully scored pipelines in the `pipelines_scored` folder
* Storing failing pipelines in the `pipelines_searched` folder
* Storing the pipeline rank in a `<pipeline_id>.rank` file alongside the pipeline in the `pipelines_ranked` folder.